### PR TITLE
Update requirements.txt -> openai 0.26.* (massively reduced package installation size)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord.py==2.1.*
 python-dotenv==0.21.*
-openai==0.25.*
+openai==0.26.*
 PyYAML==6.0
 dacite==1.6.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord.py==2.1.*
 python-dotenv==0.21.*
-openai==0.26.*
+openai>0.25
 PyYAML==6.0
 dacite==1.6.*


### PR DESCRIPTION
I've made the change and it came really handy for the build times, so I suggest to make it the norm.

I must also note that I upgraded the python version in my environment - I'm not aware of any new requirements for the 0.26's openai python release, but I did not test with the default current one.