### PR TITLE
Refactor close_thread function for efficiency and possible bugs

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -47,14 +47,17 @@ def is_last_message_stale(
 
 
 async def close_thread(thread: discord.Thread):
-    await thread.edit(name=INACTIVATE_THREAD_PREFIX)
+    await thread.edit(
+        name=INACTIVATE_THREAD_PREFIX,
+        archived=True,
+        locked=True
+    )
     await thread.send(
         embed=discord.Embed(
             description="**Thread closed** - Context limit reached, closing...",
             color=discord.Color.blue(),
         )
     )
-    await thread.edit(archived=True, locked=True)
 
 
 def should_block(guild: Optional[discord.Guild]) -> bool:


### PR DESCRIPTION
This pull request refactors the `close_thread` function to improve its efficiency and future possible bugs. Instead of making multiple API calls to edit the thread, it consolidates the changes into a single edit operation.  This reduces the number of requests made to the Discord API and enhances performance. Let me know if this doesn't work out for some reason. 
