### PR TITLE
Replace int variable name to avoid conflict with Python keyword

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -75,7 +75,7 @@ async def on_ready():
     max_tokens="How many tokens the model should output at max for each message."
 )
 async def chat_command(
-    int: discord.Interaction,
+    interaction: discord.Interaction,
     message: str,
     model: AVAILABLE_MODELS = DEFAULT_MODEL,
     temperature: Optional[float] = 1.0,
@@ -83,19 +83,19 @@ async def chat_command(
 ):
     try:
         # only support creating thread in text channel
-        if not isinstance(int.channel, discord.TextChannel):
+        if not isinstance(interaction.channel, discord.TextChannel):
             return
 
         # block servers not in allow list
-        if should_block(guild=int.guild):
+        if should_block(guild=interaction.guild):
             return
 
-        user = int.user
+        user = interaction.user
         logger.info(f"Chat command by {user} {message[:20]}")
 
         # Check for valid temperature
         if temperature is not None and (temperature < 0 or temperature > 1):
-            await int.response.send_message(
+            await interaction.response.send_message(
                 f"You supplied an invalid temperature: {temperature}. Temperature must be between 0 and 1.",
                 ephemeral=True,
             )
@@ -103,7 +103,7 @@ async def chat_command(
 
         # Check for valid max_tokens
         if max_tokens is not None and (max_tokens < 1 or max_tokens > 4096):
-            await int.response.send_message(
+            await interaction.response.send_message(
                 f"You supplied an invalid max_tokens: {max_tokens}. Max tokens must be between 1 and 4096.",
                 ephemeral=True,
             )
@@ -113,14 +113,14 @@ async def chat_command(
             # moderate the message
             flagged_str, blocked_str = moderate_message(message=message, user=user)
             await send_moderation_blocked_message(
-                guild=int.guild,
+                guild=interaction.guild,
                 user=user,
                 blocked_str=blocked_str,
                 message=message,
             )
             if len(blocked_str) > 0:
                 # message was blocked
-                await int.response.send_message(
+                await interaction.response.send_message(
                     f"Your prompt has been blocked by moderation.\n{message}",
                     ephemeral=True,
                 )
@@ -140,11 +140,11 @@ async def chat_command(
                 embed.color = discord.Color.yellow()
                 embed.title = "⚠️ This prompt was flagged by moderation."
 
-            await int.response.send_message(embed=embed)
-            response = await int.original_response()
+            await interaction.response.send_message(embed=embed)
+            response = await interaction.original_response()
 
             await send_moderation_flagged_message(
-                guild=int.guild,
+                guild=interaction.guild,
                 user=user,
                 flagged_str=flagged_str,
                 message=message,
@@ -152,7 +152,7 @@ async def chat_command(
             )
         except Exception as e:
             logger.exception(e)
-            await int.response.send_message(
+            await interaction.response.send_message(
                 f"Failed to start chat {str(e)}", ephemeral=True
             )
             return
@@ -179,7 +179,7 @@ async def chat_command(
             )
     except Exception as e:
         logger.exception(e)
-        await int.response.send_message(
+        await interaction.response.send_message(
             f"Failed to start chat {str(e)}", ephemeral=True
         )
 


### PR DESCRIPTION
The variable/param name `int` is used, which conflicts with Python's built-in `int` keyword. This can lead to unexpected behavior or confusion when working with the code.

This PR renames the variable/parameter to a more descriptive and non-conflicting name `interaction` to improve code clarity and prevent potential issues.

Changes:
- Renamed `int` variable/parameter to `interaction` in `[main.py]` file.

This change is backward-compatible and does not affect functionality.